### PR TITLE
switch `forEach()` to `for...of` loop to fix firefox

### DIFF
--- a/www/src/js/virtual_machine/index.js
+++ b/www/src/js/virtual_machine/index.js
@@ -232,13 +232,13 @@ class VMRegistersUI {
             const aliases = ic.aliases;
             if (aliases) {
                 this.ic_aliases = {}
-                aliases.keys().forEach(alias => {
+                for (const alias of aliases.keys()) {
                     const target = aliases.get(alias);
                     if (target.RegisterSpec &&  target.RegisterSpec.indirection == 0) {
                         const index = target.RegisterSpec.target;
                         this.ic_aliases[alias] = index;
                     }
-                })
+                }
             }
             console.log(aliases);
         }


### PR DESCRIPTION
`Iterator.prototype.forEach()` is apparently still experimental; "recommended for implementation" by browser vendors but not yet implemented in Firefox (at least as of Firefox 124): https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/forEach#browser_compatibility

Fixes #1