### PR TITLE
don't scroll to active line

### DIFF
--- a/www/src/js/editor/index.ts
+++ b/www/src/js/editor/index.ts
@@ -117,7 +117,8 @@ class IC10Editor {
             that.active_line_markers.set(id, session.addMarker(new Range(active_line, 0, active_line, 1), "vm_ic_active_line", "fullLine", true));
             if (that.active_session == id) {
               // editor.resize(true);
-              that.aceEditor.scrollToLine(active_line, true, true, ()=>{})
+              // TODO: Scroll to line if vm was stepped
+              //that.aceEditor.scrollToLine(active_line, true, true, ()=>{})
             }
           }
         }


### PR DESCRIPTION
this behaviour is very intrusive when editing a long file, making the editor scroll to the active line even if it's not in view. This fixes that
